### PR TITLE
Fix tabs/spaces and a few related issues

### DIFF
--- a/bin/symd
+++ b/bin/symd
@@ -106,7 +106,7 @@ elif args.d3_json:
         print("Need output filename!")
         sys.exit(1)
     yang_dict = {}
-    with open(dict_file,"r") as df:
+    with open(args.dict_file,"r") as df:
         for line in df:
             line.rstrip('\n')
             yang_model, yang_auth_email = line.partition(":")[::2]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup
 
 def read(fname):
-	return open(os.path.join(os.path.dirname(__file__), fname)).read()
+    return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 setup(name = 'symd',
       version='0.1',

--- a/symd.py
+++ b/symd.py
@@ -69,7 +69,7 @@ def get_local_yang_files(local_repos, recurse=False):
     """
     yfs = []
     if not recurse:
-       for repo in local_repos:
+        for repo in local_repos:
             if repo.endswith('/'):
                 yfs.extend(glob.glob('%s*.yang' % repo))
             else:
@@ -344,11 +344,11 @@ def print_dependency_tree_as_json(graph=None, filename=None, yang_dict={}):
                     partial_found = True
             if partial_found:
                 continue
-		node_email = yang_dict.get(node_name, None)
-		if node_email != None:
-                    output['nodes'].append({'name': node_name, 'email' : node_email})
-		else:
-                    output['nodes'].append({'name': node_name})
+        node_email = yang_dict.get(node_name, None)
+        if node_email != None:
+            output['nodes'].append({'name': node_name, 'email' : node_email})
+        else:
+            output['nodes'].append({'name': node_name})
         idx_arr.append(node_name)
     for (z, a) in graph.edges_iter():
         if a in ignore_exact or z in ignore_exact:
@@ -528,11 +528,11 @@ if __name__ == "__main__":
         if not args.json:
             print >>sys.stderr, "Need output filename!"
             sys.exit(1)
-		yang_dict = {}
-		with open(dict_file,"r") as df:
-                    for line in df:
-                        yang_model, yang_auth_email = line.partition(":")[::2]
-                        yang_dict[yang_model.strip()] = yang_auth_email
+        yang_dict = {}
+        with open(args.dict_file,"r") as df:
+            for line in df:
+                yang_model, yang_auth_email = line.partition(":")[::2]
+                yang_dict[yang_model.strip()] = yang_auth_email
         print_dependency_tree_as_json(filename=args.json, yang_dict = yang_dict)
 
     elif args.single_sankey_json:
@@ -540,11 +540,11 @@ if __name__ == "__main__":
             print("Need output filename!")
             sys.exit(1)
         g = get_subgraph_for_node(args.single_sankey_json)
-		yang_dict = {}
-		with open(dict_file,"r") as df:
-			for line in df:
-				yang_model, yang_auth_email = line.partition(":")[::2]
-				yang_dict[yang_model.strip()] = yang_auth_email
+        yang_dict = {}
+        with open(args.dict_file,"r") as df:
+            for line in df:
+                yang_model, yang_auth_email = line.partition(":")[::2]
+                yang_dict[yang_model.strip()] = yang_auth_email
         print_dependency_tree_as_json(graph=g, filename=args.json, yang_dict=yang_dict)
 
     elif args.graph:

--- a/symd/symd.py
+++ b/symd/symd.py
@@ -369,10 +369,10 @@ def return_dependency_tree_as_json(graph=None, ignore_exact=[], ignore_partial=[
                     partial_found = True
             if partial_found:
                 continue
-	draft_email = yang_dict.get(node_name, None);
-	if draft_email != None:
+        draft_email = yang_dict.get(node_name, None)
+        if draft_email != None:
             output['nodes'].append({'name': node_name, 'email' : draft_email})
-	else:
+        else:
             output['nodes'].append({'name': node_name })
 
         idx_arr.append(node_name)
@@ -420,7 +420,7 @@ def print_dependency_emails(graph=None, ignore_exact=[], ignore_partial=[], yang
         graph=graph,
         ignore_exact=ignore_exact,
         ignore_partial=ignore_partial, yang_dict=yang_dict)
-    emails = set();
+    emails = set()
     for node in output["nodes"]:
         email = node.get("email", None)
         if email != None:


### PR DESCRIPTION
2c759bb0315f added tabs in several places instead of spaces throughout, resulting in errors like:

```
Traceback (most recent call last):
  File "bin/symd", line 15, in <module>
    from symd import init
  File "lib/python3.6/site-packages/symd/__init__.py", line 1, in <module>
    from .symd import *
  File "lib/python3.6/site-packages/symd/symd.py", line 372
    draft_email = yang_dict.get(node_name, None);
                                                ^
TabError: inconsistent use of tabs and spaces in indentation
```

This fixes those errors.